### PR TITLE
学習スクリプトの出力パスと設定を整理する

### DIFF
--- a/Python/01_trend_classifier.py
+++ b/Python/01_trend_classifier.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -31,7 +32,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "trend_classifier_3c",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Label parameters
     "future_bars": 12,          # look-ahead window for labelling
     "trend_threshold": 0.0003,  # ±threshold → bullish/bearish; inside → ranging

--- a/Python/02_fvg_fill_predictor.py
+++ b/Python/02_fvg_fill_predictor.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -30,7 +31,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "fvg_fill_predictor",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # FVG detection
     "min_fvg_pips": 3.0,       # minimum FVG size in pips
     "fill_window": 24,          # bars to check for fill

--- a/Python/03_ob_quality_scorer.py
+++ b/Python/03_ob_quality_scorer.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -30,7 +31,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "ob_quality_scorer",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # OB detection
     "impulse_min_pips": 10.0,
     "ob_max_age": 100,           # max bars since OB formed to be revisited

--- a/Python/04_bos_choch_detector.py
+++ b/Python/04_bos_choch_detector.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -31,7 +32,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "bos_choch_detector",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Sequence parameters
     "seq_length": 30,         # lookback bars for LSTM input
     "future_bars": 10,        # look-ahead for labelling

--- a/Python/05_liquidity_sweep_predictor.py
+++ b/Python/05_liquidity_sweep_predictor.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -30,7 +31,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "liquidity_sweep_pred",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Liquidity detection
     "equal_tolerance_pips": 2.0,  # pips tolerance for "equal" levels
     "lookback": 50,               # bars to look back for equal levels

--- a/Python/06_entry_timing_optimizer.py
+++ b/Python/06_entry_timing_optimizer.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -30,7 +31,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "entry_timing_opt",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Zone / signal parameters
     "zone_lookback": 50,
     "max_wait_bars": 30,         # maximum bars to look for best entry

--- a/Python/07_volatility_regime.py
+++ b/Python/07_volatility_regime.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -30,7 +31,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "volatility_regime_4c",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Regime thresholds (percentiles of ATR distribution)
     "low_pct": 25,
     "normal_pct": 60,

--- a/Python/08_session_pattern.py
+++ b/Python/08_session_pattern.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir
 
 warnings.filterwarnings("ignore")
 
@@ -31,7 +32,7 @@ CONFIG = {
     "timeframe": "M5",
     "n_bars": 100_000,
     "model_name": "session_pattern_3c",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Session definitions (UTC hours)
     "sessions": {
         "asian":  (0, 8),

--- a/Python/09_mtf_confluence_scorer.py
+++ b/Python/09_mtf_confluence_scorer.py
@@ -15,6 +15,7 @@ import pandas as pd
 from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -31,7 +32,7 @@ CONFIG = {
     'base_timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'mtf_confluence_scorer',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'xgb_params': {

--- a/Python/10_price_action_classifier.py
+++ b/Python/10_price_action_classifier.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -30,7 +31,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'price_action_classifier',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'sequence_length': 20,
     'test_size': 0.2,
     'random_state': 42,

--- a/Python/11_currency_strength_predictor.py
+++ b/Python/11_currency_strength_predictor.py
@@ -16,6 +16,7 @@ import pandas as pd
 from itertools import combinations
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -31,7 +32,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'currency_strength_predictor',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'prediction_horizon': 12,

--- a/Python/12_sl_tp_optimizer.py
+++ b/Python/12_sl_tp_optimizer.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -30,7 +31,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'sl_tp_optimizer',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'pip_value': 0.0001,

--- a/Python/13_market_regime_detector.py
+++ b/Python/13_market_regime_detector.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -30,7 +31,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'market_regime_detector',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'regime_window': 50,

--- a/Python/14_swing_reversal_predictor.py
+++ b/Python/14_swing_reversal_predictor.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -30,7 +31,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'swing_reversal_predictor',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'swing_lookback': 5,

--- a/Python/15_smc_ensemble.py
+++ b/Python/15_smc_ensemble.py
@@ -16,6 +16,7 @@ import pandas as pd
 from typing import Dict, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common.paths import default_model_dir
 
 try:
     from common.data_loader import DataLoader
@@ -31,7 +32,7 @@ CONFIG = {
     'timeframe': 'M5',
     'n_bars': 100000,
     'model_name': 'smc_ensemble',
-    'output_dir': '../Files/models/',
+    'output_dir': str(default_model_dir()),
     'test_size': 0.2,
     'random_state': 42,
     'meta_lgbm_params': {

--- a/Python/common/__init__.py
+++ b/Python/common/__init__.py
@@ -11,9 +11,20 @@ Modules:
     model_utils   - Model training, hyperparameter optimization, ONNX export
 """
 
-from common.data_loader import DataLoader
-from common.feature_base import FeatureEngineer
-from common.model_utils import ModelTrainer
+from common.paths import default_model_dir, resolve_output_dir
 
-__all__ = ["DataLoader", "FeatureEngineer", "ModelTrainer"]
+try:
+    from common.data_loader import DataLoader
+    from common.feature_base import FeatureEngineer
+    from common.model_utils import ModelTrainer
+except ImportError:
+    DataLoader = FeatureEngineer = ModelTrainer = None
+
+__all__ = [
+    "DataLoader",
+    "FeatureEngineer",
+    "ModelTrainer",
+    "default_model_dir",
+    "resolve_output_dir",
+]
 __version__ = "1.0.0"

--- a/Python/common/paths.py
+++ b/Python/common/paths.py
@@ -1,0 +1,24 @@
+"""Path helpers shared by Python training scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PYTHON_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = PYTHON_DIR.parent
+
+
+def default_model_dir() -> Path:
+    """Return the repository-level model output directory."""
+    return PROJECT_ROOT / "Files" / "models"
+
+
+def resolve_output_dir(output_dir: str | Path | None = None) -> Path:
+    """Resolve an output directory independently of the current cwd."""
+    if output_dir is None:
+        return default_model_dir()
+
+    path = Path(output_dir)
+    if path.is_absolute():
+        return path
+    return (PYTHON_DIR / path).resolve()

--- a/Python/tests/test_common_modules.py
+++ b/Python/tests/test_common_modules.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from common.data_loader import DataLoader
 from common.feature_base import FeatureEngineer
 from common.model_utils import ModelTrainer
+from common.paths import default_model_dir, resolve_output_dir
 
 
 def sample_ohlc() -> pd.DataFrame:
@@ -41,6 +42,20 @@ class DataLoaderTests(unittest.TestCase):
     def test_load_requires_source(self) -> None:
         with self.assertRaises(ValueError):
             DataLoader().load(10)
+
+
+class PathHelperTests(unittest.TestCase):
+    def test_default_model_dir_is_repo_level_files_dir(self) -> None:
+        path = default_model_dir()
+
+        self.assertEqual(path.name, "models")
+        self.assertEqual(path.parent.name, "Files")
+
+    def test_resolve_output_dir_is_cwd_independent(self) -> None:
+        self.assertEqual(
+            resolve_output_dir("../Files/models"),
+            default_model_dir().resolve(),
+        )
 
 
 class FeatureEngineerTests(unittest.TestCase):

--- a/Python/train_swing_market_regime.py
+++ b/Python/train_swing_market_regime.py
@@ -28,6 +28,9 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report, confusion_matrix, accuracy_score
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from common.paths import default_model_dir
+
 warnings.filterwarnings("ignore")
 
 # ---------------------------------------------------------------------------
@@ -38,7 +41,7 @@ CONFIG = {
                 "GBPJPY", "USDCHF", "USDCAD", "NZDUSD"],
     "timeframe_d1": "D1",
     "model_name": "market_regime",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Data period
     "date_from": datetime(2023, 1, 5),
     "date_to":   datetime(2025, 12, 25),

--- a/Python/train_swing_trend_classifier.py
+++ b/Python/train_swing_trend_classifier.py
@@ -27,6 +27,9 @@ import pandas as pd
 from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import classification_report, confusion_matrix, accuracy_score
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from common.paths import default_model_dir
+
 warnings.filterwarnings("ignore")
 
 # ---------------------------------------------------------------------------
@@ -37,7 +40,7 @@ CONFIG = {
                 "GBPJPY", "USDCHF", "USDCAD", "NZDUSD"],
     "timeframe_d1": "D1",
     "model_name": "trend_classifier",
-    "output_dir": "../Files/models/",
+    "output_dir": str(default_model_dir()),
     # Data period
     "date_from": datetime(2023, 1, 5),
     "date_to":   datetime(2025, 12, 25),


### PR DESCRIPTION
## 概要

Python学習スクリプトのモデル出力先を、実行ディレクトリに依存しないリポジトリ基準のパスへ整理しました。

## 変更内容

- `common.paths` を追加し、`Files/models` の解決を共通化
- 各学習スクリプトの `CONFIG["output_dir"]` / `CONFIG['output_dir']` を共通ヘルパーに変更
- `common.__init__` でパスヘルパーだけを軽く使えるように調整
- 共通パス解決の軽量テストを追加

## 検証

- `python3 -m compileall -q Python tools`
- `python3 -m ruff check Python tools --select E9,F63,F7,F82 --output-format=github`
- `python3 -m unittest discover -s Python/tests`
- `python3 tools/check_mql5_static.py`
- `git diff --check`

Closes #7
