### PR TITLE
Python検証コマンドを整備する

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,14 +26,8 @@ jobs:
       - name: Install Python check dependencies
         run: python -m pip install --upgrade numpy pandas scikit-learn ruff
 
-      - name: Check Python syntax
-        run: python -m compileall -q Python
-
-      - name: Run focused Python lint
-        run: python -m ruff check Python --select E9,F63,F7,F82 --output-format=github
-
-      - name: Run lightweight Python tests
-        run: python -m unittest discover -s Python/tests
+      - name: Run Python checks
+        run: python tools/check_python.py
 
   mql5:
     name: MQL5 static checks

--- a/tools/check_python.py
+++ b/tools/check_python.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Run the lightweight Python validation suite used by CI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMMANDS = [
+    [sys.executable, "-m", "compileall", "-q", "Python", "tools"],
+    [
+        sys.executable,
+        "-m",
+        "ruff",
+        "check",
+        "Python",
+        "tools",
+        "--select",
+        "E9,F63,F7,F82",
+        "--output-format=github",
+    ],
+    [sys.executable, "-m", "unittest", "discover", "-s", "Python/tests"],
+]
+
+
+def main() -> int:
+    for command in COMMANDS:
+        print(f"+ {' '.join(command)}", flush=True)
+        completed = subprocess.run(command, cwd=ROOT)
+        if completed.returncode != 0:
+            return completed.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

ローカルとCIで同じ軽量Python検証を実行できるコマンドを追加しました。

## 変更内容

- `tools/check_python.py` を追加
- Python構文チェック、限定ruff lint、軽量unittestを同じ順序で実行
- GitHub ActionsのPythonジョブを `python tools/check_python.py` に集約

## 検証

- `python3 tools/check_python.py`
- `python3 tools/check_mql5_static.py`
- `git diff --check`

Closes #8
